### PR TITLE
Allow tagging

### DIFF
--- a/cacholote/cache.py
+++ b/cacholote/cache.py
@@ -50,6 +50,8 @@ def _update_last_primary_keys_and_return(
     # Get result
     result = decode.loads(cache_entry._result_as_string)
     cache_entry.counter += 1
+    if config.SETTINGS["tag"] is not None:
+        cache_entry.tag = config.SETTINGS["tag"]
     session.commit()
     LAST_PRIMARY_KEYS.update(cache_entry._primary_keys)
     return result
@@ -144,6 +146,7 @@ def cacheable(func: F) -> F:
                     key=hexdigest,
                     expiration=config.SETTINGS["expiration"],
                     result=_LOCKER,
+                    tag=config.SETTINGS["tag"],
                 )
                 session.add(cache_entry)
                 session.commit()

--- a/cacholote/clean.py
+++ b/cacholote/clean.py
@@ -114,26 +114,27 @@ class _Cleaner:
         tags_to_keep: Optional[Sequence[Optional[str]]] = None,
     ) -> None:
         # Filters
-        if tags_to_clean is not None and tags_to_keep is not None:
+        if None not in (tags_to_clean, tags_to_keep):
             raise ValueError("tags_to_clean/keep are mutually exclusive.")
-        tags = tags_to_keep if tags_to_keep is not None else tags_to_clean
         filters = []
-        if tags is not None:
-            if tags_to_keep is not None:
-                filter = sqlalchemy.or_(
-                    config.CacheEntry.tag.not_in(tags),
+        if tags_to_keep is not None:
+            filters.append(
+                sqlalchemy.or_(
+                    config.CacheEntry.tag.not_in(tags_to_keep),
                     config.CacheEntry.tag.is_not(None)
-                    if None in tags
+                    if None in tags_to_keep
                     else config.CacheEntry.tag.is_(None),
                 )
-            else:
-                filter = sqlalchemy.or_(
-                    config.CacheEntry.tag.in_(tags),
+            )
+        elif tags_to_clean is not None:
+            filters.append(
+                sqlalchemy.or_(
+                    config.CacheEntry.tag.in_(tags_to_clean),
                     config.CacheEntry.tag.is_(None)
-                    if None in tags
+                    if None in tags_to_clean
                     else config.CacheEntry.tag.is_not(None),
                 )
-            filters.append(filter)
+            )
 
         # Sorters
         if method == "LRU":

--- a/cacholote/clean.py
+++ b/cacholote/clean.py
@@ -113,9 +113,20 @@ class _Cleaner:
         tags_to_clean: Optional[Sequence[Optional[str]]] = None,
         tags_to_keep: Optional[Sequence[Optional[str]]] = None,
     ) -> None:
-        # Filters
+
+        # Check tags
         if None not in (tags_to_clean, tags_to_keep):
             raise ValueError("tags_to_clean/keep are mutually exclusive.")
+        for tags in (tags_to_clean, tags_to_keep):
+            if tags is not None and (
+                not isinstance(tags, (list, set, tuple))
+                or not all(tag is None or isinstance(tag, str) for tag in tags)
+            ):
+                raise TypeError(
+                    "tags_to_clean/keep must be None or a sequence of str/None"
+                )
+
+        # Filters
         filters = []
         if tags_to_keep is not None:
             filters.append(

--- a/cacholote/clean.py
+++ b/cacholote/clean.py
@@ -115,18 +115,18 @@ class _Cleaner:
     ) -> None:
 
         # Check tags
-        if None not in (tags_to_clean, tags_to_keep):
-            raise ValueError("tags_to_clean/keep are mutually exclusive.")
         for tags in (tags_to_clean, tags_to_keep):
             if tags is not None and (
                 not isinstance(tags, (list, set, tuple))
                 or not all(tag is None or isinstance(tag, str) for tag in tags)
             ):
                 raise TypeError(
-                    "tags_to_clean/keep must be None or a sequence of str/None"
+                    "tags_to_clean/keep must be None or a sequence of str/None."
                 )
 
         # Filters
+        if None not in (tags_to_clean, tags_to_keep):
+            raise ValueError("tags_to_clean/keep are mutually exclusive.")
         filters = []
         if tags_to_keep is not None:
             filters.append(

--- a/cacholote/clean.py
+++ b/cacholote/clean.py
@@ -123,8 +123,8 @@ class _Cleaner:
         self,
         maxsize: int,
         method: Literal["LRU", "LFU"],
-        tags_to_clean: Optional[Sequence[Optional[str]]] = None,
-        tags_to_keep: Optional[Sequence[Optional[str]]] = None,
+        tags_to_clean: Optional[Sequence[Optional[str]]],
+        tags_to_keep: Optional[Sequence[Optional[str]]],
     ) -> None:
 
         self.check_tags(tags_to_clean, tags_to_keep)

--- a/cacholote/clean.py
+++ b/cacholote/clean.py
@@ -18,8 +18,9 @@ import functools
 import json
 import logging
 import posixpath
-from typing import Any, Dict, Literal, Optional, Set
+from typing import Any, Dict, Literal, Optional, Sequence, Set
 
+import sqlalchemy
 import sqlalchemy.orm
 
 from . import config, extra_encoders, utils
@@ -106,7 +107,10 @@ class _Cleaner:
                     self.fs.rm(urlpath)
 
     def delete_cache_files(
-        self, maxsize: int, method: Literal["LRU", "LFU"] = "LRU"
+        self,
+        maxsize: int,
+        method: Literal["LRU", "LFU"],
+        tags: Optional[Sequence[Optional[str]]],
     ) -> None:
         if method == "LRU":
             sorters = [config.CacheEntry.timestamp, config.CacheEntry.counter]
@@ -116,12 +120,26 @@ class _Cleaner:
             raise ValueError("`method` must be 'LRU' or 'LFU'.")
         sorters.append(config.CacheEntry.expiration)
 
+        filters = []
+        if tags is not None:
+            if not isinstance(tags, (list, tuple, set)) or not all(
+                tag is None or isinstance(tag, str) for tag in tags
+            ):
+                raise TypeError("`tags` must be None or a sequence of strings/None")
+
+            filter = config.CacheEntry.tag.in_(tags)
+            if None in tags:
+                filter = sqlalchemy.or_(config.CacheEntry.tag.is_(None), filter)
+            filters.append(filter)
+
         if self.stop_cleaning(maxsize):
             return
 
         # Clean database files
         with sqlalchemy.orm.Session(config.SETTINGS["engine"]) as session:
-            for cache_entry in session.query(config.CacheEntry).order_by(*sorters):
+            for cache_entry in (
+                session.query(config.CacheEntry).filter(*filters).order_by(*sorters)
+            ):
                 json.loads(
                     cache_entry._result_as_string,
                     object_hook=functools.partial(
@@ -143,6 +161,7 @@ def clean_cache_files(
     maxsize: int,
     method: Literal["LRU", "LFU"] = "LRU",
     delete_unknown_files: bool = False,
+    tags: Optional[Sequence[Optional[str]]] = None,
 ) -> None:
     """Clean cache files.
 
@@ -150,15 +169,18 @@ def clean_cache_files(
     ----------
     maxsize: int
         Maximum total size of cache files (bytes).
-    method: str, default="LRU"
+    method: str, default: "LRU"
         * LRU: Last Recently Used
         * LFU: Least Frequently Used
-    delete_unknown_files: bool, default=False
+    delete_unknown_files: bool, default: False
         Delete all files that are not registered in the cache database.
+    tags: sequence of strings/None, optional, default: None
+        Tags to delete. If None, delete all cache entries.
+        To delete untagged entries, add None in the sequence (e.g., [None, 'tag1', ...])
     """
     cleaner = _Cleaner()
 
     if delete_unknown_files:
         cleaner.delete_unknown_files()
 
-    cleaner.delete_cache_files(maxsize=maxsize, method=method)
+    cleaner.delete_cache_files(maxsize=maxsize, method=method, tags=tags)

--- a/cacholote/config.py
+++ b/cacholote/config.py
@@ -46,6 +46,7 @@ class CacheEntry(Base):
         onupdate=datetime.datetime.utcnow,
     )
     counter = sqlalchemy.Column(sqlalchemy.Integer, default=0)
+    tag = sqlalchemy.Column(sqlalchemy.String)
 
     constraint = sqlalchemy.UniqueConstraint(key, expiration)
 
@@ -91,6 +92,7 @@ _SETTINGS: Dict[str, Any] = {
     "io_delete_original": False,
     "raise_all_encoding_errors": False,
     "expiration": None,
+    "tag": None,
 }
 
 
@@ -141,6 +143,9 @@ class set:
         Raise an error if an encoder does not work (i.e., do not return results).
     expiration: datetime, optional, default: None
         Expiration for cached results.
+    tag: str, optional, default: None
+        Tag for the cache entry. If None, do NOT tag.
+        Note that existing tags are overwritten.
     engine:
         `sqlalchemy` Engine. Mutually exclusive with ``cache_db_urlpath``.
     """

--- a/tests/test_30_cache.py
+++ b/tests/test_30_cache.py
@@ -136,19 +136,23 @@ def test_tag(tmpdir: pathlib.Path) -> None:
     con = sqlite3.connect(str(tmpdir / "cacholote.db"))
     cur = con.cursor()
 
-    with config.set(tag=None):
-        cached_now()
-    cur.execute("SELECT tag FROM cache_entries")
-    assert cur.fetchall() == [(None,)]
+    cached_now()
+    cur.execute("SELECT tag, counter FROM cache_entries")
+    assert cur.fetchall() == [(None, 1)]
 
-    with config.set(tag="test"):
-        # Override
+    with config.set(tag="1"):
         cached_now()
-    cur.execute("SELECT tag FROM cache_entries")
-    assert cur.fetchall() == [("test",)]
+    cur.execute("SELECT tag, counter FROM cache_entries")
+    assert cur.fetchall() == [("1", 2)]
+
+    with config.set(tag="2"):
+        # Overwrite
+        cached_now()
+    cur.execute("SELECT tag, counter FROM cache_entries")
+    assert cur.fetchall() == [("2", 3)]
 
     with config.set(tag=None):
-        # Do not override if None
+        # Do not overwrite if None
         cached_now()
-    cur.execute("SELECT tag FROM cache_entries")
-    assert cur.fetchall() == [("test",)]
+    cur.execute("SELECT tag, counter FROM cache_entries")
+    assert cur.fetchall() == [("2", 4)]

--- a/tests/test_30_cache.py
+++ b/tests/test_30_cache.py
@@ -130,3 +130,25 @@ def test_expiration() -> None:
         "key": "c3d9e414d0d32337c3672cb29b1b3cc9408001bf2d1b2a71c5e45fb6",
         "expiration": datetime.datetime(9999, 12, 31, 23, 59, 59, 999999),
     }
+
+
+def test_tag(tmpdir: pathlib.Path) -> None:
+    con = sqlite3.connect(str(tmpdir / "cacholote.db"))
+    cur = con.cursor()
+
+    with config.set(tag=None):
+        cached_now()
+    cur.execute("SELECT tag FROM cache_entries")
+    assert cur.fetchall() == [(None,)]
+
+    with config.set(tag="test"):
+        # Override
+        cached_now()
+    cur.execute("SELECT tag FROM cache_entries")
+    assert cur.fetchall() == [("test",)]
+
+    with config.set(tag=None):
+        # Do not override if None
+        cached_now()
+    cur.execute("SELECT tag FROM cache_entries")
+    assert cur.fetchall() == [("test",)]

--- a/tests/test_60_clean.py
+++ b/tests/test_60_clean.py
@@ -88,18 +88,11 @@ def test_delete_unknown_files(
 def test_clean_tagged_files(tmpdir: pathlib.Path) -> None:
     fs, dirname = utils.get_cache_files_fs_dirname()
 
-    for tag in [None, "1", "2", "3"]:
+    for tag in [None, "1", "2"]:
         tmpfile = tmpdir / f"test_{tag}.txt"
         fsspec.filesystem("file").pipe_file(tmpfile, b"1")
         with config.set(tag=tag):
             open_url(tmpfile)
 
-    clean.clean_cache_files(3, tags=["1"])
-    assert set(fs.ls(dirname)) == {
-        f"{dirname}/{fs.checksum(tmpdir / f'test_None.txt')}.txt",
-        f"{dirname}/{fs.checksum(tmpdir / f'test_2.txt')}.txt",
-        f"{dirname}/{fs.checksum(tmpdir / f'test_3.txt')}.txt",
-    }
-
     clean.clean_cache_files(1, tags=[None, "2"])
-    assert fs.ls(dirname) == [f"{dirname}/{fs.checksum(tmpdir / f'test_3.txt')}.txt"]
+    assert fs.ls(dirname) == [f"{dirname}/{fs.checksum(tmpdir / f'test_1.txt')}.txt"]

--- a/tests/test_60_clean.py
+++ b/tests/test_60_clean.py
@@ -86,12 +86,21 @@ def test_delete_unknown_files(
 
 
 @pytest.mark.parametrize(
-    "tags_to_clean, tags_to_keep", [([None, "2"], None), (None, ["1"])]
+    "tags_to_clean, tags_to_keep, expected",
+    [
+        ({None, "1"}, None, "2"),
+        ({None, "2"}, None, "1"),
+        ({"1", "2"}, None, None),
+        (None, {None}, None),
+        (None, {"1"}, "1"),
+        (None, {"2"}, "2"),
+    ],
 )
 def test_clean_tagged_files(
     tmpdir: pathlib.Path,
     tags_to_clean: Optional[Sequence[Optional[str]]],
     tags_to_keep: Optional[Sequence[Optional[str]]],
+    expected: Optional[str],
 ) -> None:
     fs, dirname = utils.get_cache_files_fs_dirname()
 
@@ -102,4 +111,6 @@ def test_clean_tagged_files(
             open_url(tmpfile)
 
     clean.clean_cache_files(1, tags_to_clean=tags_to_clean, tags_to_keep=tags_to_keep)
-    assert fs.ls(dirname) == [f"{dirname}/{fs.checksum(tmpdir / f'test_1.txt')}.txt"]
+    assert fs.ls(dirname) == [
+        f"{dirname}/{fs.checksum(tmpdir / f'test_{expected}.txt')}.txt"
+    ]

--- a/tests/test_60_clean.py
+++ b/tests/test_60_clean.py
@@ -1,6 +1,6 @@
 import pathlib
 import sqlite3
-from typing import Literal, Optional, Sequence
+from typing import Any, Literal, Optional, Sequence
 
 import fsspec
 import pytest
@@ -114,3 +114,25 @@ def test_clean_tagged_files(
     assert fs.ls(dirname) == [
         f"{dirname}/{fs.checksum(tmpdir / f'test_{expected}.txt')}.txt"
     ]
+
+
+def test_clean_tagged_files_wrong_args() -> None:
+    with pytest.raises(
+        ValueError,
+        match="tags_to_clean/keep are mutually exclusive.",
+    ):
+        clean.clean_cache_files(1, tags_to_keep=[], tags_to_clean=[])
+
+
+@pytest.mark.parametrize("wrong_type", ["1", [1]])
+def test_clean_tagged_files_wrong_types(wrong_type: Any) -> None:
+    with pytest.raises(
+        TypeError,
+        match="tags_to_clean/keep must be None or a sequence of str/None.",
+    ):
+        clean.clean_cache_files(1, tags_to_keep=wrong_type)
+    with pytest.raises(
+        TypeError,
+        match="tags_to_clean/keep must be None or a sequence of str/None.",
+    ):
+        clean.clean_cache_files(1, tags_to_clean=wrong_type)

--- a/tests/test_60_clean.py
+++ b/tests/test_60_clean.py
@@ -1,6 +1,6 @@
 import pathlib
 import sqlite3
-from typing import Literal
+from typing import Literal, Optional, Sequence
 
 import fsspec
 import pytest
@@ -85,7 +85,14 @@ def test_delete_unknown_files(
             assert fs.ls(dirname) == [f"{dirname}/unknown.txt"]
 
 
-def test_clean_tagged_files(tmpdir: pathlib.Path) -> None:
+@pytest.mark.parametrize(
+    "tags_to_clean, tags_to_keep", [([None, "2"], None), (None, ["1"])]
+)
+def test_clean_tagged_files(
+    tmpdir: pathlib.Path,
+    tags_to_clean: Optional[Sequence[Optional[str]]],
+    tags_to_keep: Optional[Sequence[Optional[str]]],
+) -> None:
     fs, dirname = utils.get_cache_files_fs_dirname()
 
     for tag in [None, "1", "2"]:
@@ -94,5 +101,5 @@ def test_clean_tagged_files(tmpdir: pathlib.Path) -> None:
         with config.set(tag=tag):
             open_url(tmpfile)
 
-    clean.clean_cache_files(1, tags=[None, "2"])
+    clean.clean_cache_files(1, tags_to_clean=tags_to_clean, tags_to_keep=tags_to_keep)
     assert fs.ls(dirname) == [f"{dirname}/{fs.checksum(tmpdir / f'test_1.txt')}.txt"]


### PR DESCRIPTION
We can now attach a tag to each cache entry:
```python
with cacholote.config.set(tag="my_tag"):
    cached_function()
```
Note that:
1. `tag = None` (default) does NOT add any tag
2. existing tags are overwritten (unless `tag is None`):
```python
with cacholote.config.set(tag=None):
    cached_function() # tag=NULL
with cacholote.config.set(tag="1"):
    cached_function() # tag=1
with cacholote.config.set(tag="2"):
    cached_function() # tag=2
with cacholote.config.set(tag=None):
    cached_function() # tag=2
```

Tags can now be used to customize the cleaner:
```python
# Do not look at tags (default):
cacholote.clean_cache_files(..., tags_to_clean=None, tags_to_keep=None)
# Clean tag="1" only:
cacholote.clean_cache_files(..., tags_to_clean=["1"], tags_to_keep=None)
# Clean everything but tag="1":
cacholote.clean_cache_files(..., tags_to_clean=None, tags_to_keep=["1"])
```
`None` in a sequence means untagged entries. For example, the following only cleans untagged entries:
```python
cacholote.clean_cache_files(..., tags_to_clean=[None], tags_to_keep=None)
```