### PR TITLE
set autoflush to false

### DIFF
--- a/cacholote/cache.py
+++ b/cacholote/cache.py
@@ -126,7 +126,9 @@ def cacheable(func: F) -> F:
                 config.CacheEntry.expiration
                 == datetime.datetime.fromisoformat(config.SETTINGS["expiration"])
             )
-        with sqlalchemy.orm.Session(config.SETTINGS["engine"]) as session:
+        with sqlalchemy.orm.Session(
+            config.SETTINGS["engine"], autoflush=False
+        ) as session:
             for cache_entry in (
                 session.query(config.CacheEntry)
                 .filter(*filters)

--- a/cacholote/clean.py
+++ b/cacholote/clean.py
@@ -86,7 +86,9 @@ class _Cleaner:
 
         unknown_sizes = {k: v for k, v in self.sizes.items() if k not in files_to_skip}
         if unknown_sizes:
-            with sqlalchemy.orm.Session(config.SETTINGS["engine"]) as session:
+            with sqlalchemy.orm.Session(
+                config.SETTINGS["engine"], autoflush=False
+            ) as session:
                 for cache_entry in session.query(config.CacheEntry):
                     json.loads(
                         cache_entry._result_as_string,
@@ -162,7 +164,9 @@ class _Cleaner:
         # Clean database files
         if self.stop_cleaning(maxsize):
             return
-        with sqlalchemy.orm.Session(config.SETTINGS["engine"]) as session:
+        with sqlalchemy.orm.Session(
+            config.SETTINGS["engine"], autoflush=False
+        ) as session:
             for cache_entry in (
                 session.query(config.CacheEntry).filter(*filters).order_by(*sorters)
             ):


### PR DESCRIPTION
Attempting to fix this error:
```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/distributed/worker.py", line 3016, in apply_function_simple
    result = function(*args, **kwargs)
  File "/src/cads-worker/cads_worker/worker.py", line 42, in submit_workflow
    func(metadata=metadata, **kwargs)
  File "/src/cacholote/cacholote/cache.py", line 169, in wrapper
    _delete_cache_entry(session, cache_entry)
  File "/src/cacholote/cacholote/cache.py", line 69, in _delete_cache_entry
    session.commit()
  File "/opt/conda/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 1451, in commit
    self._transaction.commit(_to_root=self.future)
  File "/opt/conda/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 827, in commit
    self._assert_active(prepared_ok=True)
  File "/opt/conda/lib/python3.10/site-packages/sqlalchemy/orm/session.py", line 601, in _assert_active
    raise sa_exc.PendingRollbackError(
sqlalchemy.exc.PendingRollbackError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(psycopg2.OperationalError) server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

[SQL: SELECT cache_entries.key AS cache_entries_key, cache_entries.expiration AS cache_entries_expiration, cache_entries.timestamp AS cache_entries_timestamp, cache_entries.counter AS cache_entries_counter, cache_entries.tag AS cache_entries_tag
FROM cache_entries
WHERE cache_entries.key = %(pk_1)s AND cache_entries.expiration = %(pk_2)s]
[parameters: {'pk_1': '1b57dec30eac3c33ac6d16ee3034801225f8b9406e0ef33509b0d60a', 'pk_2': datetime.datetime(9999, 12, 31, 23, 59, 59, 999999)}]
(Background on this error at: https://sqlalche.me/e/14/e3q8) (Background on this error at: https://sqlalche.me/e/14/7s2a)
```